### PR TITLE
clear the require cache to allow two instances without inadvertent mo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "async": "^1.0.0",
     "glob": "^7.1.3",
+    "import-fresh": "^3.0.0",
     "lodash": "^4.0.0",
     "moog": "^1.0.0",
-    "resolve": "^1.7.1"
+    "resolve": "^1.7.1",
+    "resolve-from": "^4.0.0"
   },
   "devDependencies": {
     "mocha": "^5.0.0"


### PR DESCRIPTION
…dification of shared definitions.

This enables `apostrophe-monitor` to work and fixes a deep bug relating to `apostrophe-multisite` as well that would otherwise eventually be a serious problem for our multisite projects.
